### PR TITLE
don't crash on loader error

### DIFF
--- a/microservices/loader/build/pulsar/loader.go
+++ b/microservices/loader/build/pulsar/loader.go
@@ -2064,13 +2064,13 @@ func bootStrapOrderData(sequenceReplayDBindex int, msgStartTime string, msgStopT
 		resp, err = http.Get(orderDumperServiceAddress + "/dumper-status")
 
 		if err != nil {
-			fmt.Println("(bootStrapOrderData) error getting order dumper status endpoint: ", err)
+			fmt.Println("(bootStrapOrderData) error getting order dumper status endpoint")
 		}
 
 		body, err = ioutil.ReadAll(resp.Body)
 
 		if err != nil {
-			fmt.Println("(bootStrapOrderData) error reading order dumper status response body: ", err)
+			fmt.Println("(bootStrapOrderData) error reading order dumper status response body")
 			break
 		}
 


### PR DESCRIPTION
Don't crash the loader service when kafka dumper is unavailable:

```
/loader
(bootStrapOrderData) GET:  http://dumper-service.ragnarok.svc.cluster.local/dumper-start?start=2022-06-24T09:22:42.000Z?stop=2022-06-23T09:22:42.000Z
(bootStrapOrderData) streaming orders from 2022-06-24T09:22:42.000Z to 2022-06-23T09:22:42.000Z
error connecting to order dumper service http://dumper-service.ragnarok.svc.cluster.local
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x846171]

goroutine 36 [running]:
main.bootStrapOrderData(0x6, 0xc00002c258, 0x18, 0xc00002c300, 0x18, 0x0)
        /app/loader.go:1990 +0x371
main.bootStrapOrderDataWrapper(0x6)
        /app/loader.go:1966 +0x45
main.main.func1()
        /app/loader.go:2221 +0xc5
created by main.main
        /app/loader.go:2212 +0x4c


```