### PR TITLE
workaround path to downsize eks node group size

### DIFF
--- a/kubernetes/eks-deploy/eks-cluster.tf
+++ b/kubernetes/eks-deploy/eks-cluster.tf
@@ -29,7 +29,7 @@ module "eks" {
   eks_managed_node_groups = {
     np001 = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 11
       desired_size   = 2
       instance_types = ["t3.xlarge"]
       disk_size      = 100
@@ -42,7 +42,7 @@ module "eks" {
     }
     np002 = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 11
       desired_size   = 2
       instance_types = ["t3.xlarge"]
       disk_size      = 50
@@ -55,7 +55,7 @@ module "eks" {
     }
     np003 = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 11
       desired_size   = 2
       instance_types = ["t3.xlarge"]
       disk_size      = 50
@@ -68,7 +68,7 @@ module "eks" {
     }
     np004 = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 11
       desired_size   = 2
       instance_types = ["t3.xlarge"]
       disk_size      = 50
@@ -81,7 +81,7 @@ module "eks" {
     }
     np005 = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 11
       desired_size   = 2
       disk_size      = 50
       instance_types = ["t3.xlarge"]


### PR DESCRIPTION
workaround for this AWS API bug:

```
[31m│[0m [0m[1m[31mError: [0m[0m[1merror updating EKS Node Group (ragnarok-eks-mjollner-dev:np005-20220624095957848500000003) config: InvalidParameterException: desired capacity 9 can't be greater than max size 3
[31m│[0m [0m{
[31m│[0m [0m  RespMetadata: {
[31m│[0m [0m    StatusCode: 400,
[31m│[0m [0m    RequestID: "c037ee45-eaef-4081-8721-197763149a8c"
[31m│[0m [0m  },
[31m│[0m [0m  ClusterName: "ragnarok-eks-mjollner-dev",
[31m│[0m [0m  Message_: "desired capacity 9 can't be greater than max size 3",
[31m│[0m [0m  NodegroupName: "np005-20220624095957848500000003"
[31m│[0m [0m}[0m
[31m│[0m [0m
[31m│[0m [0m[0m  with module.eks.module.eks_managed_node_group["np005"].aws_eks_node_group.this[0],
[31m│[0m [0m  on .terraform/modules/eks/modules/eks-managed-node-group/main.tf line 269, in resource "aws_eks_node_group" "this":
[31m│[0m [0m 269: resource "aws_eks_node_group" "this" [4m{[0m[0m
[31m│[0m [0m
[31m╵[0m[0m

```